### PR TITLE
Use godep for 'make dist'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,14 @@ VERSION=0.6
 distdir=carbonserver-$(VERSION)
 
 carbonserver:
-	GOPATH=`pwd` go build -o $@
+	GOPATH=`pwd`/Godeps/_workspace go build -o carbonserver
 
 dist:
-	mkdir -p $(distdir)
-	git archive \
-		--format=tar.gz \
-		--prefix=$(distdir)/ v$(VERSION) \
-		| tar -zxf -
-	rsync -Ca src $(distdir)/
-	tar -zcf $(distdir).tar.gz $(distdir)
+	godep save
+	mkdir $(distdir)
+	mv Godeps $(distdir)
+	cp Makefile *.go $(distdir)
+	tar zvcf $(distdir).tar.gz $(distdir)
 	rm -rf $(distdir)
 
 clean:


### PR DESCRIPTION
Update makefile to use github.com/tools/godep for building the distribution tarball.  Note this will probably require updating our rpm spec file.
